### PR TITLE
fix upgrade logic

### DIFF
--- a/src/main/java/com/indemnity83/irontank/item/ItemTankChanger.java
+++ b/src/main/java/com/indemnity83/irontank/item/ItemTankChanger.java
@@ -120,12 +120,12 @@ public class ItemTankChanger extends ItemGeneric {
         TileTank curTankTile;
         if (worldTile instanceof TileIronTank) {
             curTankTile = (TileTank) worldTile;
-            if (type.canUpgrade(((TileIronTank) curTankTile).type)) {
+            if (!type.canUpgrade(((TileIronTank) curTankTile).type)) {
                 return false;
             }
         } else if (worldTile instanceof TileTank) {
             curTankTile = (TileTank) worldTile;
-            if (type.canUpgrade(TankType.GLASS)) {
+            if (!type.canUpgrade(TankType.GLASS)) {
                 return false;
             }
         } else {

--- a/src/main/java/com/indemnity83/irontank/reference/TankChangerType.java
+++ b/src/main/java/com/indemnity83/irontank/reference/TankChangerType.java
@@ -63,7 +63,7 @@ public enum TankChangerType {
      * @return true if upgrade is allowed
      */
     public boolean canUpgrade(TankType from) {
-        return from != this.source;
+        return from == this.source;
     }
 
     TankChangerType(TankType source, TankType target, String itemName, String... recipe) {


### PR DESCRIPTION
The logic of this function was the wrong way around. If it's allowed to upgrade the tested type, the source of the upgrade should *equal* to the type.

I guess this just never got noticed because up to now nobody depended on this function