### PR TITLE
docs: note that upstream Iron Tanks is actively maintained again

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 <a href="https://github.com/Indemnity83/irontank/blob/master/LICENSE.txt"><img src="https://img.shields.io/github/license/indemnity83/irontank.svg" alt="License"></a>
 </p>
 
+> **Upstream is active again.** This repository is a fork of [Indemnity83/irontanks](https://github.com/Indemnity83/irontanks),
+> which is once more under active maintenance by its original author. The fork's changes have been folded back upstream
+> (including the 1.7.10 line). If pointing back at upstream releases is ever useful, the door's open — see this PR's
+> description for details. Either way, thanks to the GTNH team for keeping Iron Tanks alive. 🙏
+
 ## About Iron Tanks
 
 Iron Tanks is a [Buildcraft](https://minecraft.curseforge.com/projects/buildcraft) add-on for Minecraft which adds tiered capacity and special purpose tanks to the game. Iron Tanks follows strict Minecraft physics, meaning a one block space can hold 8x more stuff as long as you build the container out of diamond, and as long as you surround the glass container with obsidian blocks, it will be explosion proof. These tanks and more can add hours of fun and excitement to the game:


### PR DESCRIPTION
Hi folks 👋 — and a particular thanks to @Dream-Master, @Eldrinn-Elantey, and @UltraProdigy for the recent work.

I'm Kyle, the original author of Iron Tanks. I stepped away from modding for a good while, and in that time you all kept this running inside GTNH — thank you, genuinely. I really appreciate the care it got: the extended tiers and tooltips, the translations, the build and dependency upkeep. That's real maintenance work and it didn't go unnoticed.

I'm back and actively maintaining upstream again ([Indemnity83/irontanks](https://github.com/Indemnity83/irontanks)). I've gone through your fork and folded your changes back into the original — including the 1.7.10 line — so upstream should now be caught up with what you've done here.

Worth mentioning where upstream has gone, since it's drifted from the BuildCraft add-on it was when you forked it: it now also runs on Minecraft 26.1 as a **standalone mod with no BuildCraft dependency** — it stands on its own and interoperates with a companion mod I've been building, **Logistics: Automation**. The 1.7.10 line you know is still maintained alongside it.

**One intentional deviation worth flagging:** your extended line runs Diamond → Aluminium → Stainless Steel, where the Aluminium tank lives in the `emeraldtank` slot internally (the "emerald" name is kept, but it displays and crafts as Aluminium). Upstream I've split that one slot into two distinct 96-bucket tanks: a genuine **Emerald** tank (emerald gems) *and* a dedicated **Aluminium** tank (aluminium ingots), sitting side by side. So Diamond upgrades to *either* Emerald or Aluminium, and both upgrade into Stainless Steel — Titanium and Tungstensteel above are unchanged.

Practical heads-up from that: upstream's `emeraldtank` is now a real emerald tank again, and the aluminium content moved to its own `aluminiumtank` id — so it's not a drop-in swap if you ever diff or migrate. Happy to help map IDs if it's ever useful.

No ask attached to this, just to:
1. Say thank you,
2. Flag that divergence so it's not a surprise, and
3. Let you know the door's open — if it's ever useful to point back at upstream releases, I'm happy to coordinate tags/versioning to make it painless. But I completely get that a GTNH-integrated fork is the right call for the pack, and if you'd rather keep your own line, no hard feelings at all. The MIT license means you never owed me anything here. 🙂

---

This PR itself is just a tiny README note pointing at the active upstream — purely optional, merge or close as you see fit. The message above is the real point.

Either way — thanks for the stewardship. 🙏
